### PR TITLE
Update to use two-space indents by default.

### DIFF
--- a/src/main/kotlin/com/amazon/ion/plugin/intellij/formatting/IonLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/com/amazon/ion/plugin/intellij/formatting/IonLanguageCodeStyleSettingsProvider.kt
@@ -23,10 +23,13 @@ class IonLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider()
     }
 
     override fun customizeDefaults(commonSettings: CommonCodeStyleSettings, indentOptions: IndentOptions) {
-        // When using spaces or tabs: Use two spaces for indents.
+        // Default to use spaces instead of tabs.
+        indentOptions.USE_TAB_CHARACTER = false
+
+        // When using spaces or tabs: Default to use two spaces for indents.
         indentOptions.INDENT_SIZE = 2
 
-        // When using tabs: Treat a tab as two spaces.
+        // When using tabs: Default to display/treat a tab as two spaces wide.
         indentOptions.TAB_SIZE = 2
 
         super.customizeDefaults(commonSettings, indentOptions)

--- a/src/main/kotlin/com/amazon/ion/plugin/intellij/formatting/IonLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/com/amazon/ion/plugin/intellij/formatting/IonLanguageCodeStyleSettingsProvider.kt
@@ -23,6 +23,12 @@ class IonLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider()
     }
 
     override fun customizeDefaults(commonSettings: CommonCodeStyleSettings, indentOptions: IndentOptions) {
+        // When using spaces or tabs: Use two spaces for indents.
+        indentOptions.INDENT_SIZE = 2
+
+        // When using tabs: Treat a tab as two spaces.
+        indentOptions.TAB_SIZE = 2
+
         super.customizeDefaults(commonSettings, indentOptions)
     }
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Updates to use two-space indentation as a default. Of course, this can still be overridden by anyone with different preferences

Based on feedback outside of github from @toddjonker 

> I strongly recommend two-space indentation as best practice for Ion files. They tend to nest fairly deeply, especially when using S-expressions for DSLs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
