### PR TITLE
Enable plugin for IntelliJ 2021.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ val plugins = listOf(
     ),
     PluginDescriptor(
         since = "211",
-        until = "212.*",
+        until = "213.*",
         sdkVersion = "IC-2021.1",
         platformType = PlatformType.IdeaCommunity,
         sourceFolder = "IC-211",

--- a/resources/plugin-changenotes.html
+++ b/resources/plugin-changenotes.html
@@ -1,4 +1,8 @@
 <ul>
+    2021-12-12
+    <li>
+        Enable plugin for IntelliJ 2021.3
+    </li>
     2021-06-11
     <li>
         Adding support for IntelliJ 2021.1+ and Android Studio.


### PR DESCRIPTION
- 2021.* still works fine for 2021.3 version, so enable the plugin for that version

*Issue #, if available:*

*Description of changes:* Enable plugin to work on 2021.3 version, been using a local build for a while, all working fine.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
