### PR TITLE
Update formatting tests to use 2 spaces indents

### DIFF
--- a/src/test/kotlin/com/amazon/ion/plugin/intellij/formatting/IonBasicFormattingTest.kt
+++ b/src/test/kotlin/com/amazon/ion/plugin/intellij/formatting/IonBasicFormattingTest.kt
@@ -30,16 +30,16 @@ class IonBasicFormattingTest : IonFormatterTestBase() {
         """,
         """
         {
-            // Comments
-            another: {
-                struct: {
-                    // Upper struct comment
-                    memberA: true,
-                    // Inner struct comment
-                    memberB: false
-                }
+          // Comments
+          another: {
+            struct: {
+              // Upper struct comment
+              memberA: true,
+              // Inner struct comment
+              memberB: false
             }
-            // Around
+          }
+          // Around
         }
         """
     )
@@ -62,24 +62,24 @@ class IonBasicFormattingTest : IonFormatterTestBase() {
         """,
         """
         {
-            // Comments
-            another: {
-                struct: {
-                    // Upper struct comment
-                    memberA: true,
-                    // Inner struct comment
-                    memberB: false,
-                    transform: (join
-                        (inner
-                            element
-                        )
-                        {
-                            element: "value"
-                        }
-                    )
+          // Comments
+          another: {
+            struct: {
+              // Upper struct comment
+              memberA: true,
+              // Inner struct comment
+              memberB: false,
+              transform: (join
+                (inner
+                  element
+                )
+                {
+                  element: "value"
                 }
+              )
             }
-            // Around
+          }
+          // Around
         }
         """
     )
@@ -95,20 +95,20 @@ class IonBasicFormattingTest : IonFormatterTestBase() {
             )
         """,
         """
-            (expression // special case comment inline with expression does not move
-                (inner
-                    expression
-                )
-                {
-                    memberA: true
-                }
-                // comment
-                value
-                // comment struct
-                {
-                    memberB: true
-                }
-            )
+        (expression // special case comment inline with expression does not move
+          (inner
+            expression
+          )
+          {
+            memberA: true
+          }
+          // comment
+          value
+          // comment struct
+          {
+            memberB: true
+          }
+        )
         """,
     )
 

--- a/src/test/resources/test-data/formatter/formatter-input-struct_after.ion
+++ b/src/test/resources/test-data/formatter/formatter-input-struct_after.ion
@@ -1,10 +1,10 @@
 {
-    // Comments
-    another: {
-        struct: {
-            // Inner struct comment
-            member: true
-        }
+  // Comments
+  another: {
+    struct: {
+      // Inner struct comment
+      member: true
     }
-    // Around
+  }
+  // Around
 }


### PR DESCRIPTION
*Issue #, if available:*
#26

*Description of changes:*
In a previous commit, 55eface65b9ce08b7b93209d1e12eb418ac1ac0e, plugin was updated to format with 2 spaces instead of indent. This commit updates the formatting tests to reflect this change

This, combined with pull request #24 will allow the plugin to be built for 2021.1 - 2021.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
