### PR TITLE
Support 2022.1 EAP

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        product: [ "IC-2020.2", "IC-2021.1" ]
+        product: [ "IC-2020.2", "IC-2021.1", "221.3427-EAP-CANDIDATE-SNAPSHOT" ]
       max-parallel: 5
     env:
       PRODUCT_NAME: ${{ matrix.product }}

--- a/.github/workflows/release-eap.yml
+++ b/.github/workflows/release-eap.yml
@@ -1,0 +1,42 @@
+# Github Action Workflow for releasing a new stable version of the plugin.
+#
+# Workflow is triggered manually w/ proper access.
+#
+# Additional Docs:
+# - GitHub Actions: https://help.github.com/en/actions
+
+name: release-eap
+on:
+  # Manually run workflow to dispatch.
+  workflow_dispatch:
+jobs:
+  release:
+    strategy:
+      matrix:
+        product: [  "221.3427-EAP-CANDIDATE-SNAPSHOT" ]
+      max-parallel: 1
+    env:
+      PRODUCT_NAME: ${{ matrix.product }}
+    runs-on: ubuntu-latest
+    steps:
+      # Check out current repository
+      - name: Fetch Sources
+        uses: actions/checkout@v2
+
+      # Downloads JDK 11 AWS Corretto Build
+      - name: Download JDK
+        run: wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz --output-document jdk.tar.gz
+
+      # Setup JDK by using previously downloaded JDK.
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+          jdkFile: jdk.tar.gz
+
+      - name: Publish EAP Plugin
+        env:
+          PRODUCT_NAME: ${{ matrix.product }}
+          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_TOKEN }}
+          PUBLISH_CHANNEL: eap
+        run: ./gradlew --stacktrace publishPlugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,17 @@ val plugins = listOf(
             apiVersion = "1.4"
         ),
         dependencies = listOf("java", "Kotlin")
+    ),
+    PluginDescriptor(
+        since = "221",
+        until = "221.*",
+        sdkVersion = "221.3427-EAP-CANDIDATE-SNAPSHOT",
+        platformType = PlatformType.IdeaCommunity,
+        sourceFolder = "IC-221",
+        kotlin = KotlinOptions(
+            apiVersion = "1.5"
+        ),
+        dependencies = listOf("java", "Kotlin")
     )
 )
 

--- a/src/IC-221/kotlin/com/amazon/ion/plugin/intellij/formatting/IonFormattingModelBuilder.kt
+++ b/src/IC-221/kotlin/com/amazon/ion/plugin/intellij/formatting/IonFormattingModelBuilder.kt
@@ -1,0 +1,34 @@
+package com.amazon.ion.plugin.intellij.formatting
+
+import com.amazon.ion.plugin.intellij.formatting.blocks.IonBlockOptions
+import com.amazon.ion.plugin.intellij.formatting.blocks.RootIonBlock
+import com.intellij.formatting.FormattingContext
+import com.intellij.formatting.FormattingModel
+import com.intellij.formatting.FormattingModelBuilder
+import com.intellij.formatting.FormattingModelProvider
+
+/**
+ * Creates the block model for an Ion file.
+ *
+ * The block model will determine how elements are spaced, indented and aligned.
+ */
+class IonFormattingModelBuilder : FormattingModelBuilder {
+    override fun createModel(formattingContext: FormattingContext): FormattingModel {
+        val element = formattingContext.psiElement
+        val settings = formattingContext.codeStyleSettings
+
+        val rootBlock = RootIonBlock(
+            node = element.node,
+            options = IonBlockOptions(
+                spaceBuilder = IonCodeBlockSpacingProvider(settings),
+                codeStyle = settings
+            )
+        )
+
+
+        return FormattingModelProvider.createFormattingModelForPsiFile(
+            element.containingFile,
+            rootBlock, settings
+        )
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
#27 - Adds 2022.1 EAP profile
#28 - Adds action to release EAP profiles to eap repository

*Description of changes:*

This pr will add support to IntelliJ 2022.1 EAP and up via the JetBrains eap repository ([repositories](https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
