### PR TITLE
Automatically publish new plugin version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,14 @@
 # - GitHub Actions: https://help.github.com/en/actions
 
 name: release
+
 on:
-  # Manually run workflow to dispatch.
-  workflow_dispatch:
+  release:
+    types: [created]
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   release:
     strategy:
@@ -22,6 +27,18 @@ jobs:
       # Check out current repository
       - name: Fetch Sources
         uses: actions/checkout@v2
+      
+      # Generate resources/plugin-changenotes.html
+      - name: Generate Changenotes
+        run: |
+          gh release view --json body --jq '{ text: .body }' | gh api \
+            --method POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            --input - \
+            /markdown \
+            > resources/plugin-changenotes.html
+      - name: Log Changenotes Content
+        run: cat resources/plugin-changenotes.html
 
       # Downloads JDK 11 AWS Corretto Build
       - name: Download JDK

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ val pluginGroup: String by project
 // `pluginName_` variable ends with `_` because of the collision with Kotlin magic getter in the `intellij` closure.
 // Read more about the issue: https://github.com/JetBrains/intellij-platform-plugin-template/issues/29
 val pluginName_: String by project
-val pluginVersion: String = pluginVersion(majorVersion = "2", minorVersion = "1")
+val pluginVersion: String = pluginVersion(major = "2", minor = "1", patch = "1")
 val pluginDescriptionFile: String by project
 val pluginChangeNotesFile: String by project
 
@@ -159,9 +159,10 @@ fun readResource(name: String) = file("resources/$name").readText()
 /**
  * Function which creates a plugin version.
  */
-fun pluginVersion(majorVersion: String, minorVersion: String) =
+fun pluginVersion(major: String, minor: String, patch: String) =
     listOf(
-        majorVersion,
-        minorVersion,
+        major,
+        minor,
+        patch,
         maybeGithubRunNumber?.let { "$it-${descriptor.sdkVersion}" } ?: "0-${descriptor.sdkVersion}+alpha"
     ).joinToString(".")

--- a/resources/plugin-changenotes.html
+++ b/resources/plugin-changenotes.html
@@ -1,41 +1,8 @@
-<ul>
-    2021-12-12
-    <li>
-        Enable plugin for IntelliJ 2021.3
+<h2>
+    <a id="no-change-notes" class="anchor" href="#no-change-notes" aria-hidden="true"><span aria-hidden="true"></span></a>No Change Notes</h2>
+    <ul>
+    <li>There are no change notes for this update. Perhaps someone forgot to generate them?
     </li>
-    2021-06-11
-    <li>
-        Adding support for IntelliJ 2021.1+ and Android Studio.
-    </li>
-    2020-12-24
-    <li>
-        Complete refactor of the Amazon Ion plugin with V2 release. 🎉
-    </li>
-    <li>
-        Users with IntelliJ 2020.3+ can upgrade immediately by downloading and manually installing the JAR artifact which
-        is built by the GitHub actions flow. A future revision will publish the plugin to the JetBrains repository which
-        will allow users to download and install directly from the Plugin search menu in IntelliJ 2020.3+.
-    </li>
-    <li>
-        Updated to use Java 11 to support newer versions of IntelliJ.
-    </li>
-    <li>
-        Bad characters recovery in incorrectly formatted Ion has been improved by adding recovery statements in the BNF grammar.
-    </li>
-    <li>
-        First comment line in an Ion struct is now indented properly.
-    </li>
-    <li>
-        First struct field name/value after a comment is now indented properly.
-    </li>
-    <li>
-        Space before and after the colon in a struct field name/value has been changed to only a space after the colon to
-        closer match examples in the Ion spec.
-    </li>
-    <li>
-        Ion s-expressions will be formatted in a single line if its considered a "short" expression, currently a single element.
-    </li>
-    <li>
-        Comments after the first element in an Ion s-expression will remain on the same line as the element.
-    </li>
-</ul>
+    </ul>
+    <p><strong>Source Repository</strong>: <a href="https://github.com/amzn/ion-intellij-plugin">https://github.com/amzn/ion-intellij-plugin</a></p>
+    See the source repository for further details.


### PR DESCRIPTION
*Description of changes:* Automates the publication of a new plugin version to JetBrains when a release is cut, and uses the release changenotes for plugin changenotes. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
