### PR TITLE
Add support for breadcrumbs in `.ion` files.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
     needs: gradleValidation
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         product: [ "IC-2020.2", "IC-2021.1", "IC-2022.1" ]
       max-parallel: 5
@@ -98,6 +99,7 @@ jobs:
 
       # Publish plugin to beta channel
       - name: Publish Beta Plugin
+        if: github.repository == 'amzn/ion-intellij-plugin'
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_TOKEN }}
           PUBLISH_CHANNEL: beta
@@ -105,6 +107,7 @@ jobs:
 
       # Upload plugin artifact to make it available in the next jobs
       - name: Upload artifact
+        if: github.repository == 'amzn/ion-intellij-plugin'
         uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.product }}-plugin-artifact

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ val plugins = listOf(
     )
 )
 
-val defaultProductName = "IC-2020.2"
+val defaultProductName = "IC-2022.1"
 val productName = System.getenv("PRODUCT_NAME") ?: defaultProductName
 val maybeGithubRunNumber = System.getenv("GITHUB_RUN_NUMBER")?.toInt()
 val descriptor = plugins.first { it.sdkVersion == productName }

--- a/resources/preview.ion
+++ b/resources/preview.ion
@@ -27,5 +27,5 @@ Ion::Person::{
         Pioneer,
         'Texas Revolution',
         'The Alamo',
-    ]
+    ],
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonList.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonList.java
@@ -8,6 +8,6 @@ import com.intellij.psi.PsiElement;
 public interface IonList extends PsiElement {
 
   @Nullable
-  IonElements getElements();
+  IonListElements getListElements();
 
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonListElements.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonListElements.java
@@ -5,10 +5,9 @@ import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
-public interface IonKey extends PsiElement {
+public interface IonListElements extends PsiElement {
 
-  //WARNING: getKeyName(...) is skipped
-  //matching getKeyName(IonKey, ...)
-  //methods are not found in IonPsiUtil
+  @NotNull
+  List<IonValue> getValueList();
 
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonSexpression.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonSexpression.java
@@ -8,9 +8,6 @@ import com.intellij.psi.PsiElement;
 public interface IonSexpression extends PsiElement {
 
   @Nullable
-  IonAtoms getAtoms();
-
-  @Nullable
-  IonSexpressionOperator getSexpressionOperator();
+  IonSexpressionElements getSexpressionElements();
 
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonSexpressionAtom.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonSexpressionAtom.java
@@ -5,9 +5,9 @@ import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
-public interface IonElements extends PsiElement {
+public interface IonSexpressionAtom extends PsiElement {
 
-  @NotNull
-  List<IonValue> getValueList();
+  @Nullable
+  IonValue getValue();
 
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonSexpressionElements.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonSexpressionElements.java
@@ -5,9 +5,12 @@ import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
-public interface IonAtoms extends PsiElement {
+public interface IonSexpressionElements extends PsiElement {
 
   @NotNull
-  List<IonValue> getValueList();
+  List<IonSexpressionAtom> getSexpressionAtomList();
+
+  @Nullable
+  IonSexpressionOperator getSexpressionOperator();
 
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonTypes.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonTypes.java
@@ -9,19 +9,20 @@ import com.amazon.ion.plugin.intellij.psi.impl.*;
 public interface IonTypes {
 
   IElementType ANNOTATION = new IonElementType("ANNOTATION");
-  IElementType ATOMS = new IonElementType("ATOMS");
   IElementType BLOB = new IonElementType("BLOB");
   IElementType CLOB = new IonElementType("CLOB");
   IElementType CONTAINER = new IonElementType("CONTAINER");
-  IElementType ELEMENTS = new IonElementType("ELEMENTS");
   IElementType KEY = new IonElementType("KEY");
   IElementType LIST = new IonElementType("LIST");
+  IElementType LIST_ELEMENTS = new IonElementType("LIST_ELEMENTS");
   IElementType MEMBERS = new IonElementType("MEMBERS");
   IElementType PAIR = new IonElementType("PAIR");
   IElementType QQQ_STRING = new IonElementType("QQQ_STRING");
   IElementType QQ_STRING = new IonElementType("QQ_STRING");
   IElementType Q_STRING = new IonElementType("Q_STRING");
   IElementType SEXPRESSION = new IonElementType("SEXPRESSION");
+  IElementType SEXPRESSION_ATOM = new IonElementType("SEXPRESSION_ATOM");
+  IElementType SEXPRESSION_ELEMENTS = new IonElementType("SEXPRESSION_ELEMENTS");
   IElementType SEXPRESSION_OPERATOR = new IonElementType("SEXPRESSION_OPERATOR");
   IElementType STRING = new IonElementType("STRING");
   IElementType STRUCT = new IonElementType("STRUCT");
@@ -71,9 +72,6 @@ public interface IonTypes {
       if (type == ANNOTATION) {
         return new IonAnnotationImpl(node);
       }
-      else if (type == ATOMS) {
-        return new IonAtomsImpl(node);
-      }
       else if (type == BLOB) {
         return new IonBlobImpl(node);
       }
@@ -83,14 +81,14 @@ public interface IonTypes {
       else if (type == CONTAINER) {
         return new IonContainerImpl(node);
       }
-      else if (type == ELEMENTS) {
-        return new IonElementsImpl(node);
-      }
       else if (type == KEY) {
         return new IonKeyImpl(node);
       }
       else if (type == LIST) {
         return new IonListImpl(node);
+      }
+      else if (type == LIST_ELEMENTS) {
+        return new IonListElementsImpl(node);
       }
       else if (type == MEMBERS) {
         return new IonMembersImpl(node);
@@ -109,6 +107,12 @@ public interface IonTypes {
       }
       else if (type == SEXPRESSION) {
         return new IonSexpressionImpl(node);
+      }
+      else if (type == SEXPRESSION_ATOM) {
+        return new IonSexpressionAtomImpl(node);
+      }
+      else if (type == SEXPRESSION_ELEMENTS) {
+        return new IonSexpressionElementsImpl(node);
       }
       else if (type == SEXPRESSION_OPERATOR) {
         return new IonSexpressionOperatorImpl(node);

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonValue.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonValue.java
@@ -25,7 +25,8 @@ public interface IonValue extends PsiElement {
   @Nullable
   IonSymbol getSymbol();
 
-  @Nullable
-  String getValueAsString();
+  //WARNING: getValueAsString(...) is skipped
+  //matching getValueAsString(IonValue, ...)
+  //methods are not found in IonPsiUtil
 
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonVisitor.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/IonVisitor.java
@@ -11,10 +11,6 @@ public class IonVisitor extends PsiElementVisitor {
     visitPsiElement(o);
   }
 
-  public void visitAtoms(@NotNull IonAtoms o) {
-    visitPsiElement(o);
-  }
-
   public void visitBlob(@NotNull IonBlob o) {
     visitPsiElement(o);
   }
@@ -27,15 +23,15 @@ public class IonVisitor extends PsiElementVisitor {
     visitPsiElement(o);
   }
 
-  public void visitElements(@NotNull IonElements o) {
-    visitPsiElement(o);
-  }
-
   public void visitKey(@NotNull IonKey o) {
     visitPsiElement(o);
   }
 
   public void visitList(@NotNull IonList o) {
+    visitPsiElement(o);
+  }
+
+  public void visitListElements(@NotNull IonListElements o) {
     visitPsiElement(o);
   }
 
@@ -60,6 +56,14 @@ public class IonVisitor extends PsiElementVisitor {
   }
 
   public void visitSexpression(@NotNull IonSexpression o) {
+    visitPsiElement(o);
+  }
+
+  public void visitSexpressionAtom(@NotNull IonSexpressionAtom o) {
+    visitPsiElement(o);
+  }
+
+  public void visitSexpressionElements(@NotNull IonSexpressionElements o) {
     visitPsiElement(o);
   }
 

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonKeyImpl.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonKeyImpl.java
@@ -27,10 +27,4 @@ public class IonKeyImpl extends ASTWrapperPsiElement implements IonKey {
     else super.accept(visitor);
   }
 
-  @Override
-  @Nullable
-  public String getKeyName() {
-    return IonPsiUtil.getKeyName(this);
-  }
-
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonListElementsImpl.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonListElementsImpl.java
@@ -11,14 +11,14 @@ import static com.amazon.ion.plugin.intellij.psi.IonTypes.*;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.amazon.ion.plugin.intellij.psi.*;
 
-public class IonElementsImpl extends ASTWrapperPsiElement implements IonElements {
+public class IonListElementsImpl extends ASTWrapperPsiElement implements IonListElements {
 
-  public IonElementsImpl(@NotNull ASTNode node) {
+  public IonListElementsImpl(@NotNull ASTNode node) {
     super(node);
   }
 
   public void accept(@NotNull IonVisitor visitor) {
-    visitor.visitElements(this);
+    visitor.visitListElements(this);
   }
 
   @Override

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonListImpl.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonListImpl.java
@@ -29,8 +29,8 @@ public class IonListImpl extends ASTWrapperPsiElement implements IonList {
 
   @Override
   @Nullable
-  public IonElements getElements() {
-    return findChildByClass(IonElements.class);
+  public IonListElements getListElements() {
+    return findChildByClass(IonListElements.class);
   }
 
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonSexpressionAtomImpl.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonSexpressionAtomImpl.java
@@ -11,14 +11,14 @@ import static com.amazon.ion.plugin.intellij.psi.IonTypes.*;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.amazon.ion.plugin.intellij.psi.*;
 
-public class IonAtomsImpl extends ASTWrapperPsiElement implements IonAtoms {
+public class IonSexpressionAtomImpl extends ASTWrapperPsiElement implements IonSexpressionAtom {
 
-  public IonAtomsImpl(@NotNull ASTNode node) {
+  public IonSexpressionAtomImpl(@NotNull ASTNode node) {
     super(node);
   }
 
   public void accept(@NotNull IonVisitor visitor) {
-    visitor.visitAtoms(this);
+    visitor.visitSexpressionAtom(this);
   }
 
   @Override
@@ -28,9 +28,9 @@ public class IonAtomsImpl extends ASTWrapperPsiElement implements IonAtoms {
   }
 
   @Override
-  @NotNull
-  public List<IonValue> getValueList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, IonValue.class);
+  @Nullable
+  public IonValue getValue() {
+    return findChildByClass(IonValue.class);
   }
 
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonSexpressionElementsImpl.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonSexpressionElementsImpl.java
@@ -11,14 +11,14 @@ import static com.amazon.ion.plugin.intellij.psi.IonTypes.*;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.amazon.ion.plugin.intellij.psi.*;
 
-public class IonValueImpl extends ASTWrapperPsiElement implements IonValue {
+public class IonSexpressionElementsImpl extends ASTWrapperPsiElement implements IonSexpressionElements {
 
-  public IonValueImpl(@NotNull ASTNode node) {
+  public IonSexpressionElementsImpl(@NotNull ASTNode node) {
     super(node);
   }
 
   public void accept(@NotNull IonVisitor visitor) {
-    visitor.visitValue(this);
+    visitor.visitSexpressionElements(this);
   }
 
   @Override
@@ -29,38 +29,14 @@ public class IonValueImpl extends ASTWrapperPsiElement implements IonValue {
 
   @Override
   @NotNull
-  public List<IonAnnotation> getAnnotationList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, IonAnnotation.class);
+  public List<IonSexpressionAtom> getSexpressionAtomList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, IonSexpressionAtom.class);
   }
 
   @Override
   @Nullable
-  public IonBlob getBlob() {
-    return findChildByClass(IonBlob.class);
-  }
-
-  @Override
-  @Nullable
-  public IonClob getClob() {
-    return findChildByClass(IonClob.class);
-  }
-
-  @Override
-  @Nullable
-  public IonContainer getContainer() {
-    return findChildByClass(IonContainer.class);
-  }
-
-  @Override
-  @Nullable
-  public IonString getString() {
-    return findChildByClass(IonString.class);
-  }
-
-  @Override
-  @Nullable
-  public IonSymbol getSymbol() {
-    return findChildByClass(IonSymbol.class);
+  public IonSexpressionOperator getSexpressionOperator() {
+    return findChildByClass(IonSexpressionOperator.class);
   }
 
 }

--- a/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonSexpressionImpl.java
+++ b/src/main/gen/com/amazon/ion/plugin/intellij/psi/impl/IonSexpressionImpl.java
@@ -29,14 +29,8 @@ public class IonSexpressionImpl extends ASTWrapperPsiElement implements IonSexpr
 
   @Override
   @Nullable
-  public IonAtoms getAtoms() {
-    return findChildByClass(IonAtoms.class);
-  }
-
-  @Override
-  @Nullable
-  public IonSexpressionOperator getSexpressionOperator() {
-    return findChildByClass(IonSexpressionOperator.class);
+  public IonSexpressionElements getSexpressionElements() {
+    return findChildByClass(IonSexpressionElements.class);
   }
 
 }

--- a/src/main/kotlin/com/amazon/ion/plugin/intellij/Ion.bnf
+++ b/src/main/kotlin/com/amazon/ion/plugin/intellij/Ion.bnf
@@ -21,11 +21,13 @@ struct ::= LBRACE [members] RBRACE {pin=1}
 members ::= struct_pair*
 pair ::= COMMENT* (key SEPARATOR value)
 key ::= (QUOTE KEY_NAME QUOTE) | (QQUOTE KEY_NAME QQUOTE) | (QQQUOTE KEY_NAME QQQUOTE) | KEY_NAME {methods=[getKeyName]}
-list ::= LBRACKET [elements] RBRACKET {pin=1}
-elements ::= list_element*
-sexpression ::= (LPAREN [sexpression_operator] [atoms] RPAREN)
+list ::= LBRACKET [list_elements] RBRACKET {pin=1}
+list_elements ::= list_element*
+sexpression ::= (LPAREN [sexpression_elements] RPAREN)
+sexpression_elements ::= [sexpression_operator] atoms*
 sexpression_operator ::= (annotation)* (symbol)
-atoms ::= sexpression_atom+
+sexpression_atom ::= OPERATOR | value {pin(".*")=1 recoverWhile=not_paren_or_next_member}
+
 blob ::= LOB_START (BLOB_VALUE | BAD_CHARACTER) LOB_END
 clob ::= LOB_START (string) LOB_END
 qqq_string ::= QQQ_START (QQQ_VALUE)? QQQ_END
@@ -36,7 +38,7 @@ symbol ::= (IDENTIFIER | q_string)
 annotation ::= (IDENTIFIER | q_string) ANNOTATION_SEPARATOR
 value ::= (annotation)* (string | symbol | blob | clob | INTEGER | DECIMAL | HEXINT | BININT | BOOLEAN | NULL | IDENTIFIER | TIMESTAMP | container) {methods=[getValueAsString]}
 
-private sexpression_atom ::= OPERATOR | value {pin(".*")=1 recoverWhile=not_paren_or_next_member}
+private atoms ::= sexpression_atom+
 private struct_pair ::= pair (COMMA | &RBRACE) {pin=1 recoverWhile=not_brace_or_next_pair}
 private list_element ::= value (COMMA | &RBRACKET) {pin=1 recoverWhile=not_bracket_or_next_value}
 

--- a/src/main/kotlin/com/amazon/ion/plugin/intellij/breadcrumb/IonBreadcrumbsInfoProvider.kt
+++ b/src/main/kotlin/com/amazon/ion/plugin/intellij/breadcrumb/IonBreadcrumbsInfoProvider.kt
@@ -1,0 +1,49 @@
+package com.amazon.ion.plugin.intellij.breadcrumb
+
+import com.amazon.ion.plugin.intellij.IonLanguage
+import com.amazon.ion.plugin.intellij.psi.*
+import com.intellij.lang.Language
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
+
+/**
+ * Provides breadcrumb information for displaying path to a nested value from the root of a top-level Ion value.
+ *
+ * Only values inside a container have breadcrumb information.
+ * - If value is in a struct, the breadcrumb is the field name. E.g. `foo`
+ * - If value is in a sexp, the breadcrumb is the zero-based index of the value, in parentheses. E.g. `(2)`
+ * - If value is in a list, the breadcrumb is the zero-based index of the value, in square brackets. E.g. `[2]`
+ *
+ * What are breadcrumbs? See https://www.jetbrains.com/help/idea/settings-editor-breadcrumbs.html
+ */
+class IonBreadcrumbsInfoProvider: BreadcrumbsProvider {
+    companion object {
+        val LANGUAGES: Array<Language> = arrayOf(IonLanguage.INSTANCE)
+    }
+
+    override fun getLanguages(): Array<Language> = LANGUAGES
+
+    override fun acceptElement(element: PsiElement): Boolean {
+        return element.parent is IonMembers || element.parent is IonListElements || element.parent is IonSexpressionElements
+    }
+
+    override fun getElementInfo(element: PsiElement): String {
+        return when (val p = element.parent) {
+            is IonMembers -> (element as? IonPair)?.key?.text ?: ""
+            is IonListElements -> p.valueList.indexOf(element).takeIf { it >= 0 }?.let { "[$it]" } ?: ""
+            is IonSexpressionElements -> when (element) {
+                is IonSexpressionOperator -> "(0)"
+                is IonSexpressionAtom -> {
+                    val offset = if (p.sexpressionOperator != null) 1 else 0
+                    p.sexpressionAtomList.indexOf(element)
+                        .takeIf { it >= 0 }
+                        ?.let { "(${it + offset})" }
+                        ?: ""
+                }
+                else -> ""
+            }
+            else -> TODO("Unreachable")
+        }
+    }
+}

--- a/src/main/kotlin/com/amazon/ion/plugin/intellij/formatting/blocks/IonListBlock.kt
+++ b/src/main/kotlin/com/amazon/ion/plugin/intellij/formatting/blocks/IonListBlock.kt
@@ -15,7 +15,7 @@ class IonListBlock(
     )
 
     override val childContainerTypes: Set<IElementType> = setOf(
-        IonTypes.ELEMENTS
+        IonTypes.LIST_ELEMENTS
     )
 
     override val containerWrapperTypes: Set<IElementType> = setOf(

--- a/src/main/kotlin/com/amazon/ion/plugin/intellij/formatting/blocks/IonSExpressionBlock.kt
+++ b/src/main/kotlin/com/amazon/ion/plugin/intellij/formatting/blocks/IonSExpressionBlock.kt
@@ -25,7 +25,7 @@ class IonSExpressionBlock(
     )
 
     override val childContainerTypes: Set<IElementType> = setOf(
-        IonTypes.ATOMS
+        IonTypes.SEXPRESSION_ELEMENTS
     )
 
     override val containerWrapperTypes: Set<IElementType> = setOf(

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,8 @@
         <!-- Executes annotators against the Ion file which creates more complex color highlighting -->
         <annotator language="Ion" implementationClass="com.amazon.ion.plugin.intellij.highlight.IonSyntaxAnnotatorExecutor"/>
 
+        <breadcrumbsInfoProvider implementation="com.amazon.ion.plugin.intellij.breadcrumb.IonBreadcrumbsInfoProvider" />
+
         <!-- Ion Operator Coding Insights - ROADMAP ITEM -->
         <!--<codeInsight.lineMarkerProvider language="Ion" implementationClass="com.amazon.ion.language.markers.JavaIonOperatorMarkerProvider"/>-->
 


### PR DESCRIPTION
**Issue #, if available:**

Fixes #38 

**Description of changes:**

Adds breadcrumb support for `.ion` files.

* Position within a struct is given by the field name
* Position within a list is given by `"[" $index "]"`
* Position within a sexp is given by `"(" $index ")"`
* No information is given for position of a top-level value within the file

I thought it would be convenient to disambiguate sexp and list in the breadcrumb info, hence the `[]` and `()`.

E.g.:
```
{
  exprs: [
    (
      aaa
      +
      bbb
    ),
    (
      ccc
      +
      ddd
    ),
  ]
}
```
If you have your cursor in `bbb`, the resulting breadcrumb is ` exprs > [0] > (3) `.

For comparison, Intellij's breadcrumbs for `.json` files provides property name for elements in an object, and unadorned index for position within an array.


In order to make this work, I had to refactor the plugin's bnf grammar because otherwise operator symbols were not parsed but not made available as a `PsiElement`—that's why the diff is so large. You can ignore all files with `gen` in the path since they are automatically generated from them contents of the `.bnf` file.

Finally, I also make a few adjustments to the workflow so that it wouldn't try to publish to the beta channels from a fork.



_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
